### PR TITLE
M3: BrixCrm cannot be configured using the plugins page

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -20,8 +20,30 @@ return [
 	'version' => '2.0',
 	'author' => 'BrixCRM',
 	'services' => [
-		'events' => [
-			'mautic.brixcrm.leadbundle.subscriber' => [
+        'integrations' => [
+            'mautic.integration.brixcrm' => [
+                'class'     => \MauticPlugin\MauticBrixCRMBundle\Integration\BrixCRMIntegration::class,
+                'arguments' => [
+                    'event_dispatcher',
+                    'mautic.helper.cache_storage',
+                    'doctrine.orm.entity_manager',
+                    'session',
+                    'request_stack',
+                    'router',
+                    'translator',
+                    'logger',
+                    'mautic.helper.encryption',
+                    'mautic.lead.model.lead',
+                    'mautic.lead.model.company',
+                    'mautic.helper.paths',
+                    'mautic.core.model.notification',
+                    'mautic.lead.model.field',
+                    'mautic.plugin.model.integration_entity',
+                ],
+            ],
+        ],
+	    'events' => [
+			'mautic.integration.brixcrm.leadbundle.subscriber' => [
 				'class' => \MauticPlugin\MauticBrixCRMBundle\EventListener\LeadSubscriber::class,
 				'arguments' => [
 					'mautic.helper.integration',


### PR DESCRIPTION
Before testing: make sure this plugin is not marked as missing (`is_missing`) in the `plugins` table.

Steps to reproduce:
1. Go go the plugins page.
2. Click on the BrixCRM icon.
3. Popup will appear, but you will not be able to configure it.

Steps to test:
1. Go go the plugins page.
2. Click on the BrixCRM icon.
3. A popup will appear. You will be able to see configuration options fo the BrixCRM plugin.