### PR TITLE
Add dnc dependency to match mautic AbstractIntegration

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -39,6 +39,7 @@ return [
                     'mautic.core.model.notification',
                     'mautic.lead.model.field',
                     'mautic.plugin.model.integration_entity',
+                    'mautic.lead.model.dnc',
                 ],
             ],
         ],


### PR DESCRIPTION
Mautic 3.0.0 has DoNotContact injected in AbstractIntegration.

This PR adds the dependency in the config as BrixCRMIntegration extends CrmAbstractIntegration and CrmAbstractIntegration extends AbstractIntegration.

Ref: https://github.com/mautic/mautic/blob/3.0/app/bundles/PluginBundle/Integration/AbstractIntegration.php#L220